### PR TITLE
fix(firestore): query encoder

### DIFF
--- a/src/Infrastructure/Clients/FirestoreClientCommunicator.php
+++ b/src/Infrastructure/Clients/FirestoreClientCommunicator.php
@@ -187,6 +187,7 @@ class FirestoreClientCommunicator implements GatewayInterface
         $queryParams = [];
 
         if (isset($parts['query'])) {
+            $parts['query'] = str_replace('+', '%2B', $parts['query']);
             parse_str($parts['query'], $queryParams);
         }
 


### PR DESCRIPTION
## Description

Fix weird behavior where "+" was repl
![screenshot_2024-03-05_at_15 34 22](https://github.com/Leadsales/gateway-bridge/assets/10314128/f2b8bef3-17de-446a-a39b-adb6206f2760)
aced with empty space.


The only solution was found [here](https://stackoverflow.com/questions/47626102/php-parse-str-convert-plus-to-spaces#:~:text=This%20is%20because%20parse_str%20in,parse_str%20converts%20the%20%2B%20to%20space.).


### After the fix
<img width="1059" alt="Screenshot 2024-03-05 at 15 56 19" src="https://github.com/Leadsales/gateway-bridge/assets/10314128/ab757c7b-c1ea-4efb-935f-13fc59e9390f">

